### PR TITLE
msm_rmnet: Kill logspam

### DIFF
--- a/drivers/net/ethernet/msm/msm_rmnet.c
+++ b/drivers/net/ethernet/msm/msm_rmnet.c
@@ -717,7 +717,7 @@ static int rmnet_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		break;
 
 	default:
-		pr_err("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
+		DBG0("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
 			dev->name, cmd);
 		return -EINVAL;
 	}

--- a/drivers/net/ethernet/msm/msm_rmnet_bam.c
+++ b/drivers/net/ethernet/msm/msm_rmnet_bam.c
@@ -710,7 +710,7 @@ static int rmnet_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		break;
 
 	default:
-		pr_err("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
+		DBG0("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
 			dev->name, cmd);
 		return -EINVAL;
 	}

--- a/drivers/net/ethernet/msm/msm_rmnet_sdio.c
+++ b/drivers/net/ethernet/msm/msm_rmnet_sdio.c
@@ -619,7 +619,7 @@ static int rmnet_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		break;
 
 	default:
-		pr_err("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
+		DBG0("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
 			dev->name, cmd);
 		return -EINVAL;
 	}

--- a/drivers/net/ethernet/msm/msm_rmnet_smux.c
+++ b/drivers/net/ethernet/msm/msm_rmnet_smux.c
@@ -769,7 +769,7 @@ static int rmnet_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		break;
 
 	default:
-		pr_err("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
+		DBG0("[%s] error: rmnet_ioct called for unsupported cmd[%d]",
 			   dev->name, cmd);
 		return -EINVAL;
 	}

--- a/drivers/net/ethernet/msm/msm_rmnet_wwan.c
+++ b/drivers/net/ethernet/msm/msm_rmnet_wwan.c
@@ -613,7 +613,7 @@ static int wwan_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		     dev->name);
 		break;
 	default:
-		pr_err("[%s] error: wwan_ioct called for unsupported cmd[%d]",
+		pr_debug("[%s] error: wwan_ioct called for unsupported cmd[%d]",
 		       dev->name, cmd);
 		return -EINVAL;
 	}


### PR DESCRIPTION
 * These messages are harmless and are the result of userspace blindly
   sending various ioctls which aren't supported by rmnet.

Change-Id: I39fbf863776b8419707e8d48abaa67cc8a5bd14a