### PR TITLE
ASoC: wcd9xxx-mbhc: Force lineout event report only for headphone

### DIFF
--- a/sound/soc/codecs/wcd9xxx-mbhc.c
+++ b/sound/soc/codecs/wcd9xxx-mbhc.c
@@ -944,7 +944,8 @@ static void wcd9xxx_report_plug(struct wcd9xxx_mbhc *mbhc, int insertion,
 			wcd9xxx_detect_impedance(mbhc,
 					&mbhc->zl, &mbhc->zr);
 			if ((mbhc->zl > WCD9XXX_LINEIN_THRESHOLD) &&
-				(mbhc->zr > WCD9XXX_LINEIN_THRESHOLD)) {
+			    (mbhc->zr > WCD9XXX_LINEIN_THRESHOLD) &&
+			    (jack_type == SND_JACK_HEADPHONE)) {
 				jack_type = SND_JACK_LINEOUT;
 				mbhc->current_plug = PLUG_TYPE_HIGH_HPH;
 				mbhc->force_linein = true;


### PR DESCRIPTION
Correct plug type to lineout only if headphone is detected and
impedance of left and right is above 5000 ohm. This avoids reporting
lineout for valid headset devices like tty.

Bug: 23228540

Change-Id: Ib7d1dcdf2dd5561afce6e53e22717e79c4da61d3
Signed-off-by: Phani Kumar Uppalapati <phaniu@codeaurora.org>
Signed-off-by: Ravi Kumar Alamanda <ralama@codeaurora.org>