### PR TITLE
arm: mach-msm: pil-msa: Set the strongly-ordered attribute on DMA all…

### DIFF
--- a/arch/arm/mach-msm/pil-msa.c
+++ b/arch/arm/mach-msm/pil-msa.c
@@ -299,10 +299,12 @@ static int pil_msa_mba_init_image(struct pil_desc *pil,
 	dma_addr_t mdata_phys;
 	s32 status;
 	int ret;
+	DEFINE_DMA_ATTRS(attrs);
 
+	dma_set_attr(DMA_ATTR_STRONGLY_ORDERED, &attrs);
 	/* Make metadata physically contiguous and 4K aligned. */
-	mdata_virt = dma_alloc_coherent(pil->dev, size, &mdata_phys,
-					GFP_KERNEL);
+	mdata_virt = dma_alloc_attrs(pil->dev, size, &mdata_phys,
+					GFP_KERNEL, &attrs);
 	if (!mdata_virt) {
 		dev_err(pil->dev, "MBA metadata buffer allocation failed\n");
 		return -ENOMEM;
@@ -328,7 +330,7 @@ static int pil_msa_mba_init_image(struct pil_desc *pil,
 		ret = -EINVAL;
 	}
 
-	dma_free_coherent(pil->dev, size, mdata_virt, mdata_phys);
+	dma_free_attrs(pil->dev, size, mdata_virt, mdata_phys, &attrs);
 
 	return ret;
 }


### PR DESCRIPTION
…ocations

To completely eliminate the possibility of speculative
accesses on DMA memory, set the strongly-ordered attribute
on all such allocations.

Change-Id: I4bad68eeae33aaebb4b1a30ab7a0ba133c6a0343
Signed-off-by: Vikram Mulukutla <markivx@codeaurora.org>
Signed-off-by: Srinivasarao P <spathi@codeaurora.org>