### PR TITLE
mm: vmscan: re-use IS_ENABLED macro for ZCACHE

### DIFF
--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -1331,9 +1331,10 @@ putback_inactive_pages(struct mem_cgroup_zone *mz,
 		add_page_to_lru_list(zone, page, lru);
 
 		file = is_file_lru(lru);
-		if (IS_ENABLED(CONFIG_ZCACHE))
-			if (file)
-				SetPageWasActive(page);
+#if IS_ENABLED(CONFIG_ZCACHE)
+		if (file)
+			SetPageWasActive(page);
+#endif
 		if (is_active_lru(lru)) {
 			int numpages = hpage_nr_pages(page);
 			reclaim_stat->recent_rotated[file] += numpages;
@@ -1610,12 +1611,13 @@ static void shrink_active_list(unsigned long nr_to_scan,
 		}
 
 		ClearPageActive(page);	/* we are de-activating */
-		if (IS_ENABLED(CONFIG_ZCACHE))
-			/*
-			 * For zcache to know whether the page is from active
-			 * file list
-			 */
-			SetPageWasActive(page);
+#if IS_ENABLED(CONFIG_ZCACHE)
+		/*
+		 * For zcache to know whether the page is from active
+		 * file list
+		 */
+		SetPageWasActive(page);
+#endif
 		list_add(&page->lru, &l_inactive);
 	}
 


### PR DESCRIPTION
 * Use the #if precompilation macro to avoid compilation
    of the SetPageWasActive when building without ZCACHE

Change-Id: I85f20ee5688d73af6efaa5080482820920c9f090